### PR TITLE
Update release-flow.yml

### DIFF
--- a/.github/workflows/release-flow.yml
+++ b/.github/workflows/release-flow.yml
@@ -11,15 +11,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: 🐳 Build and bundle the Docker image
-        run: |
-          docker build . --file Dockerfile --tag headofcontent.de:${{ github.event.release.tag_name }}
-          docker save headofcontent.de -o headofcontent.de_${{ github.event.release.tag_name }}.tar
-        
-      - name: 🌥 Attach Docker image to release assets
-        uses: AButler/upload-release-assets@v2.0
+      
+      - name: 🌥 Log in to Docker Hub
+        uses: docker/login-action@v2
         with:
-          files: '*.tar'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          release-tag: ${{ github.event.release.tag_name }}
+          registry: registry.headofcontent.de
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 🐳 Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: headofcontent.de:${{ github.event.release.tag_name }}


### PR DESCRIPTION
New release flow pushes the built image directly to the Head of Registry instead of attaching it to the gh release